### PR TITLE
Moved bitness to an environment variable & update to Ubuntu 22.04

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,13 @@
-FROM ubuntu:18.04
+FROM ubuntu:22.04
 
 RUN apt update \
   && apt -y upgrade \
-  && apt install -y build-essential libc6-dev libc6-dev-i386 \
-    gcc-multilib g++-multilib clang python python-pip cmake
-RUN pip install xlsxwriter pycrypto defusedxml pyyaml matplotlib
+  && DEBIAN_FRONTEND=noninteractive apt install -y build-essential libc6-dev libc6-dev-i386 \
+    gcc-multilib g++-multilib clang python2 python-pip python2-dev cmake
+RUN python2 -m pip install xlsxwriter pycrypto defusedxml pyyaml matplotlib
+
+# Create Symbolic Link so all references to `python` resolve to `python2`
+RUN ln -s /usr/bin/python2 /usr/bin/python
 
 WORKDIR /cb-multios
 COPY . ./

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,8 @@ RUN pip install xlsxwriter pycrypto defusedxml pyyaml matplotlib
 WORKDIR /cb-multios
 COPY . ./
 
-RUN ["/bin/bash", "BITNESS=64 ./build.sh"]
+ENV BITNESS=64
+
+RUN ["/bin/bash", "./build.sh"]
 
 ENTRYPOINT "/bin/bash"

--- a/build.sh
+++ b/build.sh
@@ -7,7 +7,7 @@ DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 
 if [[ -z "${NO_PYTHON_I_KNOW_WHAT_I_AM_DOING_I_SWEAR}" ]]; then
   # Install necessary python packages
-  if ! /usr/bin/env python -c "import xlsxwriter; import Crypto" 2>/dev/null; then
+  if ! /usr/bin/env python2 -c "import xlsxwriter; import Crypto" 2>/dev/null; then
       echo "Please install required python packages" >&2
       echo "  $ sudo pip install xlsxwriter pycrypto" >&2
       exit 1
@@ -47,6 +47,7 @@ if command -v ninja >/dev/null; then
 fi
 
 # shellcheck disable=SC2086
-cmake $CMAKE_OPTS ..
+# cmake $CMAKE_OPTS ..
+cmake -DCMAKE_C_FLAGS="-fcommon" -DCMAKE_CXX_FLAGS="-fcommon" $CMAKE_OPTS ..
 
 cmake --build .


### PR DESCRIPTION
I had a problem creating the docker file with the BITNESS=64 flag in the command, so I put it in its own line of the Dockerfile.

Additionally, I changed the Dockerfile to use Ubuntu:22.04.
Changes relating to Ubuntu22.04 include
 - Specifying Python2 (yuck), as previous versions installed `python` (which installed python2), but we need to now specify `python2` (including `python-pip` and `python2-dev`)
   - Additionally I made a symbolic link in `/usr/bin` from `python` to `python2`, as a `python` executable is not provided but is referenced by some scripts, so to keep compatibility we need this link.
 - Flags `-fcommon` were added to cmake during the build, as updated gcc doesn't like the programs as they are
   - [Reference issue from main repo](https://github.com/trailofbits/cb-multios/issues/81)